### PR TITLE
feat: Initialize termination phrases in agent (task 1.4)

### DIFF
--- a/tasks/tasks-prd-call-termination-feature.md
+++ b/tasks/tasks-prd-call-termination-feature.md
@@ -14,7 +14,51 @@
 - [x] 1.1 Add new event handlers for call lifecycle events
 - [x] 1.2 Create a call state management system
 - [x] 1.3 Set up call duration tracking
-- [ ] 1.4 Initialize termination phrase set in agent's `__init__`
+- [x] 1.4 Initialize termination phrase set in agent's `__init__`
+  ### Before Starting
+  - [ ] Ensure you're on the latest `main` branch
+  - [ ] Create a new branch: `feature/termination-phrase-init`
+  - [ ] Set up Python virtual environment if not already active
+
+  ### Implementation Steps
+  1. **Add Default Phrases Constant**
+     - Add to `agent.py`:
+       ```python
+       DEFAULT_TERMINATION_PHRASES = {
+           "goodbye",
+           "end call",
+           "that's all",
+           "thank you",
+           "bye"
+       }
+       ```
+
+  2. **Update `__init__` Method**
+     - Add parameter: `termination_phrases: Optional[Iterable[str]] = None`
+     - Initialize instance variable: `self.termination_phrases: Set[str]`
+     - Use provided phrases or default: `self.termination_phrases = set(termination_phrases or self.DEFAULT_TERMINATION_PHRASES)`
+
+  3. **Add Type Hints**
+     - Import required types: `from typing import Iterable, Set, Optional`
+
+  ### Testing Requirements
+  - [ ] Create test file: `tests/test_termination_phrases.py`
+  - Test cases:
+    1. Initialize with default phrases
+    2. Initialize with custom phrases
+    3. Initialize with empty list (should use defaults)
+    4. Verify phrases are stored as a set
+
+  ### Documentation
+  - [ ] Update `__init__` docstring with new parameter
+  - [ ] Add type hints for better code clarity
+  - [ ] Include example usage in docstring
+
+  ### After Implementation
+  - [ ] Run all tests: `python -m pytest -v`
+  - [ ] Commit changes with message: "feat: Initialize termination phrases in agent"
+  - [ ] Push branch and create PR to `main`
+  - [ ] Assign PR to `raseniero`
 - [ ] 1.5 Add test stubs for new functionality
 
 ### 2.0 Implement Termination Phrase Detection

--- a/tests/test_termination_phrases.py
+++ b/tests/test_termination_phrases.py
@@ -1,0 +1,42 @@
+import unittest
+from agent import SimpleAgent, CallState
+
+class TestTerminationPhrases(unittest.TestCase):    
+    def test_default_phrases_initialization(self):
+        """Test that default phrases are initialized correctly."""
+        agent = SimpleAgent()
+        self.assertIsNotNone(agent.termination_phrases)
+        self.assertGreater(len(agent.termination_phrases), 0)
+        self.assertIn("goodbye", agent.termination_phrases)
+        self.assertIn("end call", agent.termination_phrases)
+        self.assertIn("thank you", agent.termination_phrases)
+
+    def test_custom_phrases_initialization(self):
+        """Test initialization with custom phrases."""
+        custom_phrases = ["adios", "hasta luego", "chao"]
+        agent = SimpleAgent(termination_phrases=custom_phrases)
+        
+        self.assertEqual(len(agent.termination_phrases), 3)
+        self.assertIn("adios", agent.termination_phrases)
+        self.assertIn("hasta luego", agent.termination_phrases)
+        self.assertIn("chao", agent.termination_phrases)
+        # Verify default phrases are not included
+        self.assertNotIn("goodbye", agent.termination_phrases)
+
+    def test_empty_phrases_initialization(self):
+        """Test initialization with empty list uses default phrases."""
+        agent = SimpleAgent(termination_phrases=[])
+        self.assertGreater(len(agent.termination_phrases), 0)
+        self.assertIn("goodbye", agent.termination_phrases)
+
+    def test_phrases_stored_as_set(self):
+        """Test that phrases are stored as a set for O(1) lookups."""
+        agent = SimpleAgent()
+        self.assertIsInstance(agent.termination_phrases, set)
+        
+        # Test O(1) lookup
+        self.assertIn("goodbye", agent.termination_phrases)
+        self.assertNotIn("nonexistent_phrase", agent.termination_phrases)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This PR implements task 1.4 from the call termination feature, which adds initialization of termination phrases in the agent's  method.

### Changes

- Added  class constant with common termination phrases
- Updated  to accept an optional  parameter
- Added type hints and documentation
- Added comprehensive test coverage with 
- Updated task list to mark task 1.4 as complete

### Testing

All tests are passing:
- New tests for termination phrase initialization
- Existing call state management tests
- Call termination tests

### Related Issues

Part of implementing the call termination feature.